### PR TITLE
added tests for UIView applyGradient()

### DIFF
--- a/Tests/UIKitTests/UIViewExtensionsTests.swift
+++ b/Tests/UIKitTests/UIViewExtensionsTests.swift
@@ -378,6 +378,116 @@ final class UIViewExtensionsTests: XCTestCase {
         XCTAssert(view.gestureRecognizers!.isEmpty)
     }
 
+    func testApplyGradient() {
+        // topToBottom
+        let view0 = UIView()
+        XCTAssertNil(view0.layer.sublayers)
+        view0.applyGradient(
+            colors: [.red, .orange, .green, .blue],
+            locations: [0.0, 0.333, 0.667, 1.0],
+            direction: .topToBottom
+        )
+        XCTAssertNotNil(view0.layer.sublayers)
+        if let sublayers = view0.layer.sublayers as? [CAGradientLayer] {
+            XCTAssertEqual(sublayers.count, 1)
+            XCTAssertTrue(sublayers[0].startPoint.x.isEqual(to: 0.5))
+            XCTAssertTrue(sublayers[0].startPoint.y.isEqual(to: 0.0))
+            XCTAssertTrue(sublayers[0].endPoint.x.isEqual(to: 0.5))
+            XCTAssertTrue(sublayers[0].endPoint.y.isEqual(to: 1.0))
+            XCTAssertEqual(sublayers[0].colors?.count, 4)
+            XCTAssertEqual(sublayers[0].colors?[0] as! CGColor, UIColor.red.cgColor)
+            XCTAssertEqual(sublayers[0].colors?[1] as! CGColor, UIColor.orange.cgColor)
+            XCTAssertEqual(sublayers[0].colors?[2] as! CGColor, UIColor.green.cgColor)
+            XCTAssertEqual(sublayers[0].colors?[3] as! CGColor, UIColor.blue.cgColor)
+            XCTAssertEqual(sublayers[0].locations?.count, 4)
+            XCTAssertNotNil(sublayers[0].locations?[0].isEqual(to: 0.0))
+            XCTAssertNotNil(sublayers[0].locations?[1].isEqual(to: 0.333))
+            XCTAssertNotNil(sublayers[0].locations?[2].isEqual(to: 0.667))
+            XCTAssertNotNil(sublayers[0].locations?[3].isEqual(to: 1.0))
+        }
+
+        // bottomToTop
+        let view1 = UIView()
+        XCTAssertNil(view1.layer.sublayers)
+        view1.applyGradient(
+            colors: [.red, .orange, .green, .blue],
+            locations: [0.0, 0.333, 0.667, 1.0],
+            direction: .bottomToTop
+        )
+        XCTAssertNotNil(view1.layer.sublayers)
+        if let sublayers = view1.layer.sublayers as? [CAGradientLayer] {
+            XCTAssertEqual(sublayers.count, 1)
+            XCTAssertTrue(sublayers[0].startPoint.x.isEqual(to: 0.5))
+            XCTAssertTrue(sublayers[0].startPoint.y.isEqual(to: 1.0))
+            XCTAssertTrue(sublayers[0].endPoint.x.isEqual(to: 0.5))
+            XCTAssertTrue(sublayers[0].endPoint.y.isEqual(to: 0.0))
+            XCTAssertEqual(sublayers[0].colors?.count, 4)
+            XCTAssertEqual(sublayers[0].colors?[0] as! CGColor, UIColor.red.cgColor)
+            XCTAssertEqual(sublayers[0].colors?[1] as! CGColor, UIColor.orange.cgColor)
+            XCTAssertEqual(sublayers[0].colors?[2] as! CGColor, UIColor.green.cgColor)
+            XCTAssertEqual(sublayers[0].colors?[3] as! CGColor, UIColor.blue.cgColor)
+            XCTAssertEqual(sublayers[0].locations?.count, 4)
+            XCTAssertNotNil(sublayers[0].locations?[0].isEqual(to: 0.0))
+            XCTAssertNotNil(sublayers[0].locations?[1].isEqual(to: 0.333))
+            XCTAssertNotNil(sublayers[0].locations?[2].isEqual(to: 0.667))
+            XCTAssertNotNil(sublayers[0].locations?[3].isEqual(to: 1.0))
+        }
+
+        // leftToRight
+        let view2 = UIView()
+        XCTAssertNil(view2.layer.sublayers)
+        view2.applyGradient(
+            colors: [.red, .orange, .green, .blue],
+            locations: [0.0, 0.333, 0.667, 1.0],
+            direction: .leftToRight
+        )
+        XCTAssertNotNil(view2.layer.sublayers)
+        if let sublayers = view2.layer.sublayers as? [CAGradientLayer] {
+            XCTAssertEqual(sublayers.count, 1)
+            XCTAssertTrue(sublayers[0].startPoint.x.isEqual(to: 0.0))
+            XCTAssertTrue(sublayers[0].startPoint.y.isEqual(to: 0.5))
+            XCTAssertTrue(sublayers[0].endPoint.x.isEqual(to: 1.0))
+            XCTAssertTrue(sublayers[0].endPoint.y.isEqual(to: 0.5))
+            XCTAssertEqual(sublayers[0].colors?.count, 4)
+            XCTAssertEqual(sublayers[0].colors?[0] as! CGColor, UIColor.red.cgColor)
+            XCTAssertEqual(sublayers[0].colors?[1] as! CGColor, UIColor.orange.cgColor)
+            XCTAssertEqual(sublayers[0].colors?[2] as! CGColor, UIColor.green.cgColor)
+            XCTAssertEqual(sublayers[0].colors?[3] as! CGColor, UIColor.blue.cgColor)
+            XCTAssertEqual(sublayers[0].locations?.count, 4)
+            XCTAssertNotNil(sublayers[0].locations?[0].isEqual(to: 0.0))
+            XCTAssertNotNil(sublayers[0].locations?[1].isEqual(to: 0.333))
+            XCTAssertNotNil(sublayers[0].locations?[2].isEqual(to: 0.667))
+            XCTAssertNotNil(sublayers[0].locations?[3].isEqual(to: 1.0))
+        }
+
+        // rightToLeft
+        let view3 = UIView()
+        XCTAssertNil(view3.layer.sublayers)
+        view3.applyGradient(
+            colors: [.red, .orange, .green, .blue],
+            locations: [0.0, 0.333, 0.667, 1.0],
+            direction: .rightToLeft
+        )
+        XCTAssertNotNil(view3.layer.sublayers)
+        if let sublayers = view3.layer.sublayers as? [CAGradientLayer] {
+            XCTAssertEqual(sublayers.count, 1)
+            XCTAssertTrue(sublayers[0].startPoint.x.isEqual(to: 1.0))
+            XCTAssertTrue(sublayers[0].startPoint.y.isEqual(to: 0.5))
+            XCTAssertTrue(sublayers[0].endPoint.x.isEqual(to: 0.0))
+            XCTAssertTrue(sublayers[0].endPoint.y.isEqual(to: 0.5))
+            XCTAssertEqual(sublayers[0].colors?.count, 4)
+            XCTAssertEqual(sublayers[0].colors?[0] as! CGColor, UIColor.red.cgColor)
+            XCTAssertEqual(sublayers[0].colors?[1] as! CGColor, UIColor.orange.cgColor)
+            XCTAssertEqual(sublayers[0].colors?[2] as! CGColor, UIColor.green.cgColor)
+            XCTAssertEqual(sublayers[0].colors?[3] as! CGColor, UIColor.blue.cgColor)
+            XCTAssertEqual(sublayers[0].locations?.count, 4)
+            XCTAssertNotNil(sublayers[0].locations?[0].isEqual(to: 0.0))
+            XCTAssertNotNil(sublayers[0].locations?[1].isEqual(to: 0.333))
+            XCTAssertNotNil(sublayers[0].locations?[2].isEqual(to: 0.667))
+            XCTAssertNotNil(sublayers[0].locations?[3].isEqual(to: 1.0))
+        }
+    }
+
     func testAnchor() {
         let view = UIView()
         let subview = UIView()


### PR DESCRIPTION
hello @Andy0570 ,

I added a unit test function for your `applyGradient` PR - https://github.com/SwifterSwift/SwifterSwift/pull/1039

It tests the results of applyGradient() in all 4 directions.

You should be able to merge it into your code.  If not you can just copy the function.

Also, in the `applyGradient` function, did you intend to use `Color`?  Just `Color` did not compile for me.  I had to use `UIColor`.  I wasn't sure if you had an extension that implemented `Color` or if your code compiles as-is.
https://github.com/SwifterSwift/SwifterSwift/pull/1039/files#diff-55da4bac07fa471f5c1a645fb21e6981a2730c1e9ac2936bb09c90daa60e3a15R497

## Checklist
<!--- Please go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked the [**Contributing Guidelines**](https://github.com/SwifterSwift/SwifterSwift/blob/master/CONTRIBUTING.md) before creating this request.
- [x] New extensions are written in Swift 5.0.
- [x] New extensions support iOS 10.0+ / tvOS 9.0+ / macOS 10.10+ / watchOS 2.0+, or use `@available` if not.
- [x] I have added tests for new extensions, and they passed.
- [x] All extensions have a **clear** comments explaining their functionality, all parameters and return type in English.
- [x] All extensions are declared as **public**.
- [ ] I have added a [changelog](https://github.com/SwifterSwift/SwifterSwift/blob/master/CHANGELOG_GUIDELINES.md) entry describing my changes.
